### PR TITLE
Add failover when songbook generation fails

### DIFF
--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -28,7 +28,6 @@ jobs:
           echo "Building songs..."
           if ! python util/build_songs.py; then
             echo "GITHUB WORKFLOW: Build songs failed — creating empty file as fallback."
-            mkdir -p build/dist
             echo "{}" > pages/songbook/songs.json
           fi
       


### PR DESCRIPTION
Sometimes the For-mand breaks the songbook, this shouldn't affect our
agile development
